### PR TITLE
Allow UsePackwerk to move all files, not just ruby files

### DIFF
--- a/lib/use_packwerk/private.rb
+++ b/lib/use_packwerk/private.rb
@@ -189,7 +189,7 @@ module UsePackwerk
           file_paths = paths_relative_to_root.flat_map do |path|
             origin_pathname = Pathname.new(path).cleanpath
             if origin_pathname.directory?
-              origin_pathname.glob('**/*.rb').map(&:to_s)
+              origin_pathname.glob('**/*.*').map(&:to_s)
             else
               path
             end


### PR DESCRIPTION
I think this will be helpful and necessary for moving packs to be child packs, as some packs have .yml files that need to be moved too.

This already works for individual files, but just not directories.