### PR TITLE
Add UsePackwerk.move_to_parent! API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    use_packwerk (0.52.0)
+    use_packwerk (0.53.0)
       code_ownership
       colorize
       package_protections

--- a/lib/use_packwerk.rb
+++ b/lib/use_packwerk.rb
@@ -102,6 +102,25 @@ module UsePackwerk
 
   sig do
     params(
+      pack_name: String,
+      parent_name: String,
+      per_file_processors: T::Array[PerFileProcessorInterface],
+    ).void
+  end
+  def self.move_to_parent!(
+    pack_name:,
+    parent_name:,
+    per_file_processors: []
+  )
+    Private.move_to_parent!(
+      pack_name: pack_name,
+      parent_name: parent_name,
+      per_file_processors: per_file_processors,
+    )
+  end
+
+  sig do
+    params(
       pack_name: T.nilable(String),
       limit: Integer,
     ).void

--- a/lib/use_packwerk.rb
+++ b/lib/use_packwerk.rb
@@ -61,11 +61,39 @@ module UsePackwerk
     paths_relative_to_root: [],
     per_file_processors: []
   )
+    Logging.section('👋 Hi!') do
+      intro = <<~INTRO
+        You are moving a file to a pack, which is great. Check out #{UsePackwerk.config.documentation_link} for more info!
+
+        Please bring any questions or issues you have in your development process to #ruby-modularity or #product-infrastructure.
+        We'd be happy to try to help through pairing, accepting feedback, changing our process, changing our tools, and more.
+      INTRO
+      Logging.print_bold_green(intro)
+    end
+
     Private.move_to_pack!(
       pack_name: pack_name,
       paths_relative_to_root: paths_relative_to_root,
       per_file_processors: per_file_processors,
     )
+
+    Logging.section('Next steps') do
+      next_steps = <<~NEXT_STEPS
+        Your next steps might be:
+
+        1) Run `bin/packwerk update-deprecations` to update the violations. Make sure to run `spring stop` if you've added new load paths (new top-level directories) in your pack.
+
+        2) Update TODO lists for rubocop implemented protections. See #{UsePackwerk.config.documentation_link} for more info
+
+        3) Touch base with each team who owns files involved in this move
+
+        4) Expose public API in #{pack_name}/app/public. Try `bin/use_packwerk make_public #{pack_name}/path/to/file.rb`
+
+        5) Update your readme at #{pack_name}/README.md
+      NEXT_STEPS
+
+      Logging.print_bold_green(next_steps)
+    end
   end
 
   sig do
@@ -78,10 +106,33 @@ module UsePackwerk
     paths_relative_to_root: [],
     per_file_processors: []
   )
+    Logging.section('Making files public') do
+      intro = <<~INTRO
+        You are moving some files into public API. See #{UsePackwerk.config.documentation_link} for other utilities!
+      INTRO
+      Logging.print_bold_green(intro)
+    end
+
     Private.make_public!(
       paths_relative_to_root: paths_relative_to_root,
       per_file_processors: per_file_processors
     )
+  
+    Logging.section('Next steps') do
+      next_steps = <<~NEXT_STEPS
+        Your next steps might be:
+
+        1) Run `bin/packwerk update-deprecations` to update the violations. Make sure to run `spring stop` if you've added new load paths (new top-level directories) in your pack.
+
+        2) Update TODO lists for rubocop implemented protections. See #{UsePackwerk.config.documentation_link} for more info
+
+        3) Work to migrate clients of private API to your new public API
+
+        4) Update your README at packs/your_package_name/README.md
+      NEXT_STEPS
+
+      Logging.print_bold_green(next_steps)
+    end
   end
 
   sig do
@@ -94,10 +145,29 @@ module UsePackwerk
     pack_name:,
     dependency_name:
   )
+    Logging.section('Adding a dependency') do
+      intro = <<~INTRO
+        You are adding a dependency. See #{UsePackwerk.config.documentation_link} for other utilities!
+      INTRO
+      Logging.print_bold_green(intro)
+    end
+
     Private.add_dependency!(
       pack_name: pack_name,
       dependency_name: dependency_name
     )
+
+    Logging.section('Next steps') do
+      next_steps = <<~NEXT_STEPS
+        Your next steps might be:
+
+        1) Run `bin/packwerk validate` to ensure you haven't introduced a cyclic dependency
+
+        2) Run `bin/packwerk update-deprecations` to update the violations.
+      NEXT_STEPS
+
+      Logging.print_bold_green(next_steps)
+    end
   end
 
   sig do
@@ -112,11 +182,33 @@ module UsePackwerk
     parent_name:,
     per_file_processors: []
   )
+    Logging.section('👋 Hi!') do
+      intro = <<~INTRO
+        You are moving one pack to be a child of a different pack. Check out #{UsePackwerk.config.documentation_link} for more info!
+
+        Please bring any questions or issues you have in your development process to #ruby-modularity or #product-infrastructure.
+        We'd be happy to try to help through pairing, accepting feedback, changing our process, changing our tools, and more.
+      INTRO
+      Logging.print_bold_green(intro)
+    end
+
     Private.move_to_parent!(
       pack_name: pack_name,
       parent_name: parent_name,
       per_file_processors: per_file_processors,
     )
+
+    Logging.section('Next steps') do
+      next_steps = <<~NEXT_STEPS
+        Your next steps might be:
+
+        1) Delete the old pack when things look good: `rm -rf #{pack_name}`
+
+        2) Run `bin/packwerk update-deprecations` to update the violations. Make sure to run `spring stop` first.
+      NEXT_STEPS
+
+      Logging.print_bold_green(next_steps)
+    end
   end
 
   sig do

--- a/lib/use_packwerk/cli.rb
+++ b/lib/use_packwerk/cli.rb
@@ -67,5 +67,15 @@ module UsePackwerk
         per_file_processors: [UsePackwerk::RubocopPostProcessor.new, UsePackwerk::CodeOwnershipPostProcessor.new],
       )
     end
+
+    desc "move_to_parent packs/parent_pack packs/child_pack", "Pass in a parent pack and another pack to be made as a child to the parent pack!"
+    sig { params(parent_name: String, pack_name: String).void }
+    def move_to_parent(parent_name, pack_name)
+      UsePackwerk.move_to_parent!(
+        parent_name: parent_name,
+        pack_name: pack_name,
+        per_file_processors: [UsePackwerk::RubocopPostProcessor.new, UsePackwerk::CodeOwnershipPostProcessor.new],
+      )
+    end
   end
 end

--- a/lib/use_packwerk/logging.rb
+++ b/lib/use_packwerk/logging.rb
@@ -9,24 +9,29 @@ module UsePackwerk
     sig { params(title: String, block: T.proc.void).void }
     def self.section(title, &block)
       print_divider
-      puts ColorizedString.new("#{title}").green.bold
-      puts "\n"
+      out ColorizedString.new("#{title}").green.bold
+      out "\n"
       yield
     end
 
     sig { params(text: String).void }
     def self.print_bold_green(text)
-      puts ColorizedString.new(text).green.bold
+      out ColorizedString.new(text).green.bold
     end
 
     sig { params(text: String).void }
     def self.print(text)
-      puts text
+      out text
     end
 
     sig { void }
     def self.print_divider
-      puts '=' * 100
+      out '=' * 100
+    end
+
+    sig { params(str: String).void }
+    def self.out(str)
+      puts str
     end
   end
 end

--- a/lib/use_packwerk/private.rb
+++ b/lib/use_packwerk/private.rb
@@ -96,16 +96,6 @@ module UsePackwerk
         raise StandardError.new("Can not find package with name #{pack_name}. Make sure the argument is of the form `packs/my_pack/`")
       end
 
-      Logging.section('👋 Hi!') do
-        intro = <<~INTRO
-          You are moving a file to a pack, which is great. Check out #{UsePackwerk.config.documentation_link} for more info!
-
-          Please bring any questions or issues you have in your development process to #ruby-modularity or #product-infrastructure.
-          We'd be happy to try to help through pairing, accepting feedback, changing our process, changing our tools, and more.
-        INTRO
-        Logging.print_bold_green(intro)
-      end
-
       add_public_directory(package)
       add_readme_todo(package)
       package_location = package.directory
@@ -128,7 +118,10 @@ module UsePackwerk
             # Later, if we choose to go back to moving whole directories at a time, it should be a refactor and all tests should still pass
             #
             if origin_pathname.directory?
-              origin_pathname.glob('**/*.*')
+              origin_pathname.glob('**/*.*').reject do |path|
+                path.to_s.include?(ParsePackwerk::PACKAGE_YML_NAME) ||
+                path.to_s.include?(ParsePackwerk::DEPRECATED_REFERENCES_YML_NAME)
+              end
             else
               origin_pathname
             end
@@ -150,24 +143,6 @@ module UsePackwerk
       per_file_processors.each do |per_file_processor|
         per_file_processor.print_final_message!
       end
-
-      Logging.section('Next steps') do
-        next_steps = <<~NEXT_STEPS
-          Your next steps might be:
-
-          1) Run `bin/packwerk update-deprecations` to update the violations. Make sure to run `spring stop` if you've added new load paths (new top-level directories) in your pack.
-
-          2) Update TODO lists for rubocop implemented protections. See #{UsePackwerk.config.documentation_link} for more info
-
-          3) Touch base with each team who owns files involved in this move
-
-          4) Expose public API in #{pack_name}/app/public. Try `bin/use_packwerk make_public #{pack_name}/path/to/file.rb`
-
-          5) Update your readme at #{pack_name}/README.md
-        NEXT_STEPS
-
-        Logging.print_bold_green(next_steps)
-      end
     end
 
   sig do
@@ -182,16 +157,6 @@ module UsePackwerk
     parent_name:,
     per_file_processors: []
   )
-    Logging.section('👋 Hi!') do
-      intro = <<~INTRO
-        You are moving one pack to be a child of a different pack.. Check out #{UsePackwerk.config.documentation_link} for more info!
-
-        Please bring any questions or issues you have in your development process to #ruby-modularity or #product-infrastructure.
-        We'd be happy to try to help through pairing, accepting feedback, changing our process, changing our tools, and more.
-      INTRO
-      Logging.print_bold_green(intro)
-    end
-
     pack_name = Private.clean_pack_name(pack_name)
     package = ParsePackwerk.all.find { |package| package.name == pack_name }
     if package.nil?
@@ -225,28 +190,13 @@ module UsePackwerk
       per_file_processors: per_file_processors,
     )
 
+    # Then delete the old package.yml and deprecated_references.yml files
+    package.yml.delete
+    deprecated_references_file = ParsePackwerk::DeprecatedReferences.for(package).pathname
+    deprecated_references_file.delete if deprecated_references_file.exist?
+
     # Add a dependency from parent to child
     self.add_dependency!(pack_name: parent_name, dependency_name: new_package_name)
-
-    # Delete the old package.yml
-    package.yml.delete
-
-    # Delete the old deprecated_references file
-    ParsePackwerk::DeprecatedReferences.for(package).pathname.delete
-
-    Logging.section('Next steps') do
-      next_steps = <<~NEXT_STEPS
-        Your next steps might be:
-
-        1) Delete the old pack when things look good: `rm -rf #{package.directory}`
-
-        2) Run `bin/packwerk update-deprecations` to update the violations. Make sure to run `spring stop` first.
-
-        3) Update your readme at #{new_package_name}/README.md
-      NEXT_STEPS
-
-      Logging.print_bold_green(next_steps)
-    end
   end
 
     sig do
@@ -256,13 +206,6 @@ module UsePackwerk
       ).void
     end
     def self.make_public!(paths_relative_to_root:, per_file_processors:)
-      Logging.section('Making files public') do
-        intro = <<~INTRO
-          You are moving some files into public API. See #{UsePackwerk.config.documentation_link} for other utilities!
-        INTRO
-        Logging.print_bold_green(intro)
-      end
-
       if paths_relative_to_root.any?
         Logging.section('File Operations') do
           file_paths = paths_relative_to_root.flat_map do |path|
@@ -292,22 +235,6 @@ module UsePackwerk
           end
         end
       end
-      
-      Logging.section('Next steps') do
-        next_steps = <<~NEXT_STEPS
-          Your next steps might be:
-
-          1) Run `bin/packwerk update-deprecations` to update the violations. Make sure to run `spring stop` if you've added new load paths (new top-level directories) in your pack.
-
-          2) Update TODO lists for rubocop implemented protections. See #{UsePackwerk.config.documentation_link} for more info
-
-          3) Work to migrate clients of private API to your new public API
-
-          4) Update your README at packs/your_package_name/README.md
-        NEXT_STEPS
-
-        Logging.print_bold_green(next_steps)
-      end
     end
 
     sig do
@@ -317,13 +244,6 @@ module UsePackwerk
       ).void
     end
     def self.add_dependency!(pack_name:, dependency_name:)
-      Logging.section('Adding a dependency') do
-        intro = <<~INTRO
-          You are adding a dependency. See #{UsePackwerk.config.documentation_link} for other utilities!
-        INTRO
-        Logging.print_bold_green(intro)
-      end
-
       all_packages = ParsePackwerk.all
 
       pack_name = Private.clean_pack_name(pack_name)
@@ -346,18 +266,6 @@ module UsePackwerk
         metadata: package.metadata,
       )
       ParsePackwerk.write_package_yml!(new_package)
-      
-      Logging.section('Next steps') do
-        next_steps = <<~NEXT_STEPS
-          Your next steps might be:
-
-          1) Run `bin/packwerk validate` to ensure you haven't introduced a cyclic dependency
-
-          2) Run `bin/packwerk update-deprecations` to update the violations.
-        NEXT_STEPS
-
-        Logging.print_bold_green(next_steps)
-      end
     end
 
     sig { params(file_move_operation: FileMoveOperation, per_file_processors: T::Array[UsePackwerk::PerFileProcessorInterface]).void }

--- a/lib/use_packwerk/private.rb
+++ b/lib/use_packwerk/private.rb
@@ -166,7 +166,7 @@ module UsePackwerk
     parent_name = Private.clean_pack_name(parent_name)
     parent_package = ParsePackwerk.all.find { |package| package.name == parent_name }
     if parent_package.nil?
-      raise StandardError.new("Can not find package with name #{parent_name}. Make sure the argument is of the form `packs/my_pack/`")
+      parent_package = create_pack_if_not_exists!(pack_name: parent_name, enforce_privacy: true, enforce_dependencies: true)
     end
 
     # First we create a new pack that has the exact same properties of the old one!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,6 +49,7 @@ sig do
     protections: T.untyped,
     global_namespaces: T::Array[String],
     visible_to: T::Array[String],
+    metadata: T.untyped,
     owner: T.nilable(String)
   ).void
 end
@@ -60,6 +61,7 @@ def write_package_yml(
   protections: {},
   global_namespaces: [],
   visible_to: [],
+  metadata: {},
   owner: nil
 )
   defaults = {
@@ -70,7 +72,7 @@ def write_package_yml(
     'prevent_other_packages_from_using_this_package_without_explicit_visibility' => 'fail_never',
   }
   protections_with_defaults = defaults.merge(protections)
-  metadata = { 'protections' => protections_with_defaults }
+  metadata.merge!({ 'protections' => protections_with_defaults })
 
   if owner
     metadata.merge!({ 'owner' => owner })

--- a/spec/use_packwerk_spec.rb
+++ b/spec/use_packwerk_spec.rb
@@ -1050,7 +1050,6 @@ RSpec.describe UsePackwerk do
     end
   end
 
-
   describe '.add_dependency!' do
     context 'pack has no dependencies' do
       it 'adds the dependency' do

--- a/spec/use_packwerk_spec.rb
+++ b/spec/use_packwerk_spec.rb
@@ -1213,6 +1213,24 @@ RSpec.describe UsePackwerk do
 
       OUTPUT
     end
+
+    context 'parent pack does not already exist' do
+      it 'creates it' do
+        # Parent pack does not exist!
+        # write_package_yml('packs/fruits')
+
+        write_package_yml('packs/apples')
+
+        UsePackwerk.move_to_parent!(
+          pack_name: 'packs/apples',
+          parent_name: 'packs/fruits',
+        )
+
+        ParsePackwerk.bust_cache!
+        expect(Pathname.new('packs/apples')).to exist
+        expect(ParsePackwerk.find('packs/fruits').dependencies).to eq(['packs/fruits/apples'])
+      end
+    end
   end
 
   # This will soon be moved into `query_packwerk`

--- a/spec/use_packwerk_spec.rb
+++ b/spec/use_packwerk_spec.rb
@@ -1132,16 +1132,17 @@ RSpec.describe UsePackwerk do
       write_file('packs/apples/app/services/apples/some_yml.yml')
       write_file('packs/apples/app/services/apples.rb')
       write_file('packs/apples/app/services/apples/foo.rb')
+      write_file('packs/apples/README.md')
 
       UsePackwerk.move_to_parent!(
         pack_name: 'packs/apples',
-        parent_pack: 'packs/fruits',
+        parent_name: 'packs/fruits',
       )
 
       ParsePackwerk.bust_cache!
 
       expect(ParsePackwerk.find('packs/apples')).to be_nil
-      actual_package = ParsePackwerk.find('packs/apples/fruits')
+      actual_package = ParsePackwerk.find('packs/fruits/apples')
       expect(actual_package).to_not be_nil
       expect(actual_package.metadata['custom_field']).to eq 'custom value'
       expect(actual_package.dependencies).to eq(['packs/other_pack'])
@@ -1150,6 +1151,7 @@ RSpec.describe UsePackwerk do
         'packs/fruits/apples/app/services/apples/some_yml.yml',
         'packs/fruits/apples/app/services/apples.rb',
         'packs/fruits/apples/app/services/apples/foo.rb',
+        'packs/fruits/apples/README.md',
       ])
 
       expect_files_to_not_exist([
@@ -1158,9 +1160,12 @@ RSpec.describe UsePackwerk do
         'packs/apples/app/services/apples/foo.rb',
         'packs/apples/package.yml',
         'packs/apples/deprecated_references.yml',
+        'packs/apples/README.md',
       ])
 
       expect(Pathname.new('packs/apples')).to_not exist
+
+      expect(ParsePackwerk.find('packs/fruits').dependencies).to eq(['packs/fruits/apples'])
     end
   end
 

--- a/use_packwerk.gemspec
+++ b/use_packwerk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'use_packwerk'
-  spec.version       = '0.52.0'
+  spec.version       = '0.53.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 


### PR DESCRIPTION
I realized a `bin/use_packwerk move_to_parent packs/parent_pack packs/child_pack` command will be sorely needed if we don't want folks to follow a somewhat convoluted, multi-step process to make a pack a child pack. I am hoping this will lead to a lot more exploration for users.

This PR in ZP demonstrates the use: https://github.com/Gusto/zenpayroll/pull/146088
