### PR TITLE
Improve UX for UsePackwerk.move_to_parent!

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    use_packwerk (0.53.0)
+    use_packwerk (0.54.0)
       code_ownership
       colorize
       package_protections
@@ -33,7 +33,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.6.2)
     method_source (1.0.0)
-    minitest (5.16.2)
+    minitest (5.16.3)
     package_protections (1.4.0)
       activesupport
       parse_packwerk

--- a/lib/use_packwerk/private.rb
+++ b/lib/use_packwerk/private.rb
@@ -203,7 +203,7 @@ module UsePackwerk
         new_dependencies += [new_package_name]
       end
 
-      new_package = ParsePackwerk::Package.new(
+      new_other_package = ParsePackwerk::Package.new(
         name: other_package.name,
         enforce_privacy: other_package.enforce_dependencies,
         enforce_dependencies: other_package.enforce_dependencies,
@@ -211,7 +211,16 @@ module UsePackwerk
         metadata: other_package.metadata,
       )
 
-      ParsePackwerk.write_package_yml!(new_package)
+      ParsePackwerk.write_package_yml!(new_other_package)
+    end
+
+    sorbet_config = Pathname.new('sorbet/config')
+    if sorbet_config.exist?
+      UsePackwerk.replace_in_file(
+        file: sorbet_config.to_s,
+        find: package.directory.join('spec'),
+        replace_with: new_package.directory.join('spec'),
+      )
     end
   end
 

--- a/spec/use_packwerk_spec.rb
+++ b/spec/use_packwerk_spec.rb
@@ -1214,6 +1214,22 @@ RSpec.describe UsePackwerk do
       OUTPUT
     end
 
+    it 'rewrites other packs package.yml files to point to the new nested package' do
+      write_package_yml('packs/fruits', dependencies: ['packs/apples'])
+      write_package_yml('packs/other_pack', dependencies: ['packs/apples', 'packs/something_else'])
+      write_package_yml('packs/apples')
+
+      UsePackwerk.move_to_parent!(
+        pack_name: 'packs/apples',
+        parent_name: 'packs/fruits',
+      )
+
+      ParsePackwerk.bust_cache!
+
+      expect(ParsePackwerk.find('packs/fruits').dependencies).to eq(['packs/fruits/apples'])
+      expect(ParsePackwerk.find('packs/other_pack').dependencies).to eq(['packs/fruits/apples', 'packs/something_else'])
+    end
+
     context 'parent pack does not already exist' do
       it 'creates it' do
         # Parent pack does not exist!

--- a/use_packwerk.gemspec
+++ b/use_packwerk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'use_packwerk'
-  spec.version       = '0.53.0'
+  spec.version       = '0.54.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 


### PR DESCRIPTION
# Summary

I ran an experiment in ZP to nest a pack.

Here's friction I discovered, with a 
- ✅`sorbet/config` ignores a lot of spec files. We might want to auto-migrate those ignores for users.
- A lot of `package.yml` files will reference the old packs in their dependencies. This led to two pieces of friction:
  - According to the validation, we must actually remove these, because nothing should depend on child packs. I think we should REMOVE this validation until there is an easier way to promote a child pack's public API to the parent pack. Otherwise, there is a huge barrier of entry for nested packs where folks will have to migrate all of their child packs public API to the parent pack. This validation lives in ZP right now so will be changed there.
  - ✅ This requires changing the name of the packs in each parent pack. I think I should update `move_to_parent` to do this for the user since we have commands to rewrite `package.yml` files with a new list of dependencies.
- `.rubocop.yml` is hard-coded to `packs/*/app/...` type paths, so I needed to expand this. This configuration lives in ZP, so I changed it there.

# Commits
- add failing test
- fix failing test
- add other failing test
- fix spec
- bump version
