### PR TITLE
Fix issue with bin/packs command having no output

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    use_packwerk (0.57.10)
+    use_packwerk (0.57.11)
       code_ownership
       colorize
       package_protections

--- a/lib/use_packwerk/private/interactive_cli/use_cases/update_deprecations.rb
+++ b/lib/use_packwerk/private/interactive_cli/use_cases/update_deprecations.rb
@@ -16,7 +16,7 @@ module UsePackwerk
 
           sig { override.params(prompt: TTY::Prompt).void }
           def perform!(prompt)
-            `bin/packwerk update-deprecations`
+            system('bin/packwerk update-deprecations')
           end
         end
       end

--- a/lib/use_packwerk/private/interactive_cli/use_cases/validate.rb
+++ b/lib/use_packwerk/private/interactive_cli/use_cases/validate.rb
@@ -16,7 +16,7 @@ module UsePackwerk
 
           sig { override.params(prompt: TTY::Prompt).void }
           def perform!(prompt)
-            `bin/packwerk validate`
+            system('bin/packwerk validate')
           end
         end
       end

--- a/use_packwerk.gemspec
+++ b/use_packwerk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'use_packwerk'
-  spec.version       = '0.57.10'
+  spec.version       = '0.57.11'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 


### PR DESCRIPTION
This fixes an issue where we weren't forwarding terminal output to the main terminal, resulting in an unexpected lack of visible progress.

# Before
```
~/workspace/zenpayroll - (main) $ bin/packs
Hello! What would you like to do? Run bin/packwerk update-deprecations
Running via Spring preloader in process 49546
~/workspace/zenpayroll - (main) $ 
```

# After
```
~/workspace/zenpayroll - (main) $ bin/packs
Hello! What would you like to do? Run bin/packwerk update-deprecations
[TEST PROF INFO] Spring detected
Running via Spring preloader in process 49853
📦 Packwerk is inspecting X files
# lots of dots
📦 Finished in 8.58 seconds

No offenses detected
✅ `deprecated_references.yml` has been updated.
```
