### PR TITLE
Use GH CLI to create GH release rather than rely on open source action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,8 +20,6 @@ jobs:
           GIT_NAME: ${{secrets.ALEX_GIT_NAME}}
           RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
       - name: Create GitHub Release
+        run: gh release create v${{steps.tag-and-push-gem.outputs.gem_version}} --generate-notes
         uses: softprops/action-gh-release@cd28b0f5ee8571b76cfdaa62a30d51d752317477
         if: ${{ steps.tag-and-push-gem.outputs.new_version == 'true' }}
-        with:
-          tag_name: v${{steps.tag-and-push-gem.outputs.gem_version}}
-          generate_release_notes: true


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows

Github actions can use the GH CLI. I think using github's officially supported API will be a better option.

Note we were previously using https://github.com/softprops/action-gh-release

We are not using any of its more advanced features so I think the GH CLI will work just fine for now, and is easier to understand.