### PR TITLE
Use updated publish-rubygems-action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@8230315d06ad95c617244d2f265d237a1682d445
       - name: Tag and Push Gem
         id: tag-and-push-gem
-        uses: discourse/publish-rubygems-action@2d713f2092b4f02da811f4b591a10b6b56f0780e
+        uses: discourse/publish-rubygems-action@a3753e0ecc0c9f53b87c993ac854de93b39c4b53
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           GIT_EMAIL: ${{secrets.ALEX_GIT_EMAIL}}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    use_packwerk (0.60.0)
+    use_packwerk (0.60.1)
       code_ownership
       colorize
       package_protections

--- a/use_packwerk.gemspec
+++ b/use_packwerk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'use_packwerk'
-  spec.version       = '0.60.0'
+  spec.version       = '0.60.1'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 


### PR DESCRIPTION
This gets rid of a deprecation warning in the CD pipeline, e.g.: https://github.com/rubyatscale/use_packwerk/actions/runs/3321794584

```
deploy
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-command
```
