### PR TITLE
Consolidate bin/use_packwerk into bin/packs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    use_packwerk (0.64.0)
+    use_packwerk (0.65.0)
       code_ownership
       colorize
       packwerk (>= 2.2.1)

--- a/README.md
+++ b/README.md
@@ -4,26 +4,26 @@ UsePackwerk is a gem that helps in creating and maintaining packs. It exists to 
 
 ## Usage
 ### General Help
-`bin/use_packwerk --help`
+`bin/packs --help` or just `bin/packs` to enter interactive mode.
 
 ### Pack Creation
-`bin/use_packwerk create packs/your_pack_name_here`
+`bin/packs create packs/your_pack_name_here`
 
 ### Moving files to packs
-`bin/use_packwerk move packs/your_pack_name_here path/to/file.rb path/to/directory`
+`bin/packs move packs/your_pack_name_here path/to/file.rb path/to/directory`
 This is used for moving files into a pack (the pack must already exist).
 Note this works for moving files to packs from the monolith or from other packs
 
 Make sure there are no spaces between the comma-separated list of paths of directories.
 
 ### Moving a file to public API
-`bin/use_packwerk make_public path/to/file.rb,path/to/directory`
+`bin/packs make_public path/to/file.rb,path/to/directory`
 This moves a file or directory to public API (that is -- the `app/public` folder).
 
 Make sure there are no spaces between the comma-separated list of paths of directories.
 
 ### Listing top privacy violations
-`bin/use_packwerk list_top_privacy_violations packs/my_pack`
+`bin/packs list_top_privacy_violations packs/my_pack`
 Want to create interfaces? Not sure how your pack's code is being used?
 
 You can use this command to list the top privacy violations.
@@ -31,7 +31,7 @@ You can use this command to list the top privacy violations.
 If no pack name is passed in, this will list out violations across all packs.
 
 ### Listing top dependency violations
-`bin/use_packwerk list_top_dependency_violations packs/my_pack`
+`bin/packs list_top_dependency_violations packs/my_pack`
 Want to see who is depending on you? Not sure how your pack's code is being used in an unstated way
 
 You can use this command to list the top dependency violations.
@@ -39,7 +39,7 @@ You can use this command to list the top dependency violations.
 If no pack name is passed in, this will list out violations across all packs.
 
 ### Adding a dependency
-`bin/use_packwerk add_dependency packs/my_pack packs/dependency_pack_name`
+`bin/packs add_dependency packs/my_pack packs/dependency_pack_name`
 
 This can be used to quickly modify a `package.yml` file and add a dependency. It also cleans up the list of dependencies to sort the list and remove redundant entries.
 

--- a/advanced_usage.md
+++ b/advanced_usage.md
@@ -4,7 +4,7 @@
 ```ruby
 UsePackwerk.create_pack!(
     # This determines whether your package.yml in your new package will enforce privacy. See packwerk documentation for more details on this attribute.
-    # This is an optional parameter (default is true). See https://github.com/Gusto/use_packwerk/discussions/19
+    # This is an optional parameter (default is true). See https://github.com/Gusto/packs/discussions/19
     enforce_privacy: false,
     # ... other parameters
 )
@@ -18,7 +18,7 @@ You can pass in an array of application specific behavior into the `per_file_pro
 See `rubocop_post_processor.rb` as an example of renaming files in `.rubocop_todo.yml` automatically, which is something you may want to do (as you do not want to fix all style errors when you're just moving a file).
 
 # First-Time Configuration (per repo, not per developer)
-If you install binstubs, it allows simpler commands: `bin/use_packwerk` rather than `bundle exec use_packwerk`.
+If you install binstubs, it allows simpler commands: `bin/packs` rather than `bundle exec packs`.
 
 Install binstubs using:
-`bundle binstubs use_packwerk`
+`bundle binstubs packs`

--- a/bin/packs
+++ b/bin/packs
@@ -2,4 +2,9 @@
 # typed: strict
 
 require_relative '../lib/use_packwerk'
-UsePackwerk.start_interactive_mode!
+
+if ARGV.empty?
+  UsePackwerk.start_interactive_mode!
+else
+  UsePackwerk::CLI.start(ARGV)
+end

--- a/bin/use_packwerk
+++ b/bin/use_packwerk
@@ -1,5 +1,0 @@
-#!/usr/bin/env ruby
-# typed: strict
-
-require_relative '../lib/use_packwerk'
-UsePackwerk::CLI.start(ARGV)

--- a/lib/use_packwerk/cli.rb
+++ b/lib/use_packwerk/cli.rb
@@ -16,7 +16,7 @@ module UsePackwerk
     long_desc <<~LONG_DESC
       Use this to add a dependency between packs.
 
-      When you use bin/use_packwerk add_dependency packs/from_pack packs/to_pack, this command will
+      When you use bin/packs add_dependency packs/from_pack packs/to_pack, this command will
       modify packs/from_pack/package.yml's list of dependencies and add packs/to_pack.
 
       This command will also sort the list and make it unique.

--- a/lib/use_packwerk/user_event_logger.rb
+++ b/lib/use_packwerk/user_event_logger.rb
@@ -19,13 +19,13 @@ module UsePackwerk
       <<~MSG
         Your next steps might be:
 
-        1) Move files into your pack with `bin/use_packwerk move #{pack_name} path/to/file.rb`
+        1) Move files into your pack with `bin/packs move #{pack_name} path/to/file.rb`
 
         2) Run `bin/packwerk update-deprecations` to update the violations. Make sure to run `spring stop` if you've added new load paths (new top-level directories) in your pack.
 
         3) Update TODO lists for rubocop implemented protections. See #{documentation_link} for more info
 
-        4) Expose public API in #{pack_name}/app/public. Try `bin/use_packwerk make_public #{pack_name}/path/to/file.rb`
+        4) Expose public API in #{pack_name}/app/public. Try `bin/packs make_public #{pack_name}/path/to/file.rb`
 
         5) Update your readme at #{pack_name}/README.md
       MSG
@@ -49,7 +49,7 @@ module UsePackwerk
 
         3) Touch base with each team who owns files involved in this move
 
-        4) Expose public API in #{pack_name}/app/public. Try `bin/use_packwerk make_public #{pack_name}/path/to/file.rb`
+        4) Expose public API in #{pack_name}/app/public. Try `bin/packs make_public #{pack_name}/path/to/file.rb`
 
         5) Update your readme at #{pack_name}/README.md
       MSG
@@ -125,10 +125,10 @@ module UsePackwerk
         You can prevent other packs from using private API by using packwerk.
 
         Want to find how your private API is being used today?
-        Try running: `bin/use_packwerk list_top_privacy_violations #{pack_name}`
+        Try running: `bin/packs list_top_privacy_violations #{pack_name}`
 
         Want to move something into this folder?
-        Try running: `bin/use_packwerk make_public #{pack_name}/path/to/file.rb`
+        Try running: `bin/packs make_public #{pack_name}/path/to/file.rb`
 
         One more thing -- feel free to delete this file and replace it with a README.md describing your package in the main package directory.
 
@@ -170,7 +170,7 @@ module UsePackwerk
       else
         pack_specific_content = <<~PACK_CONTENT
           You are listing top #{limit} dependency violations for #{pack_name}. See #{documentation_link} for other utilities!
-          Pass in a limit to display more or less, e.g. `bin/use_packwerk list_top_dependency_violations #{pack_name} -l 1000`
+          Pass in a limit to display more or less, e.g. `bin/packs list_top_dependency_violations #{pack_name} -l 1000`
 
           This script is intended to help you find which of YOUR pack's private classes, constants, or modules other packs are using the most.
           Anything not in #{pack_name}/app/public is considered private API.
@@ -211,7 +211,7 @@ module UsePackwerk
       if pack_name.nil?
         pack_specific_content = <<~PACK_CONTENT
           You are listing top #{limit} privacy violations for all packs. See #{documentation_link} for other utilities!
-          Pass in a limit to display more or less, e.g. `bin/use_packwerk list_top_privacy_violations #{pack_name} -l 1000`
+          Pass in a limit to display more or less, e.g. `bin/packs list_top_privacy_violations #{pack_name} -l 1000`
 
           This script is intended to help you find which of YOUR pack's private classes, constants, or modules other packs are using the most.
           Anything not in pack_name/app/public is considered private API.
@@ -219,7 +219,7 @@ module UsePackwerk
       else
         pack_specific_content = <<~PACK_CONTENT
           You are listing top #{limit} privacy violations for #{pack_name}. See #{documentation_link} for other utilities!
-          Pass in a limit to display more or less, e.g. `bin/use_packwerk list_top_privacy_violations #{pack_name} -l 1000`
+          Pass in a limit to display more or less, e.g. `bin/packs list_top_privacy_violations #{pack_name} -l 1000`
 
           This script is intended to help you find which of YOUR pack's private classes, constants, or modules other packs are using the most.
           Anything not in #{pack_name}/app/public is considered private API.
@@ -253,7 +253,7 @@ module UsePackwerk
             - packs/other_pack_a: 1
             - packs/other_pack_b: 1
 
-        Lastly, remember you can use `bin/use_packwerk make_public #{pack_name}/path/to/file.rb` to make your class, constant, or module public API.
+        Lastly, remember you can use `bin/packs make_public #{pack_name}/path/to/file.rb` to make your class, constant, or module public API.
       MSG
     end
 

--- a/spec/use_packwerk_spec.rb
+++ b/spec/use_packwerk_spec.rb
@@ -174,10 +174,10 @@ RSpec.describe UsePackwerk do
           You can prevent other packs from using private API by using packwerk.
 
           Want to find how your private API is being used today?
-          Try running: `bin/use_packwerk list_top_privacy_violations packs/organisms`
+          Try running: `bin/packs list_top_privacy_violations packs/organisms`
 
           Want to move something into this folder?
-          Try running: `bin/use_packwerk make_public packs/organisms/path/to/file.rb`
+          Try running: `bin/packs make_public packs/organisms/path/to/file.rb`
 
           One more thing -- feel free to delete this file and replace it with a README.md describing your package in the main package directory.
 
@@ -751,10 +751,10 @@ RSpec.describe UsePackwerk do
           You can prevent other packs from using private API by using packwerk.
 
           Want to find how your private API is being used today?
-          Try running: `bin/use_packwerk list_top_privacy_violations packs/organisms`
+          Try running: `bin/packs list_top_privacy_violations packs/organisms`
 
           Want to move something into this folder?
-          Try running: `bin/use_packwerk make_public packs/organisms/path/to/file.rb`
+          Try running: `bin/packs make_public packs/organisms/path/to/file.rb`
 
           One more thing -- feel free to delete this file and replace it with a README.md describing your package in the main package directory.
 

--- a/use_packwerk.gemspec
+++ b/use_packwerk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'use_packwerk'
-  spec.version       = '0.64.0'
+  spec.version       = '0.65.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   # https://guides.rubygems.org/make-your-own-gem/#adding-an-executable
   # and
   # https://bundler.io/blog/2015/03/20/moving-bins-to-exe.html
-  spec.executables = %w[use_packwerk packs]
+  spec.executables = %w[packs]
 
   spec.add_dependency 'code_ownership'
   spec.add_dependency 'colorize'


### PR DESCRIPTION
<img width="1271" alt="Screenshot 2022-11-16 at 3 59 25 PM" src="https://user-images.githubusercontent.com/3311200/202293095-5c015af9-a84a-4712-80eb-76490ea65abc.png">

This PR moves us to a single CLI tool, `bin/packs`. If any args are supplied, it dispatches to the "manual" mode, letting this CLI tool be used manually and interactively.