### PR TITLE
Allow bin/packs move and bin/packs make_public to regenerate the rubocop TODO

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.21.0)
       parser (>= 3.1.1.0)
-    rubocop-packs (0.0.24)
+    rubocop-packs (0.0.27)
       activesupport
       parse_packwerk
       rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    use_packwerk (0.67.0)
+    use_packwerk (0.68.0)
       code_ownership
       colorize
       packwerk (>= 2.2.1)

--- a/lib/use_packwerk/cli.rb
+++ b/lib/use_packwerk/cli.rb
@@ -93,7 +93,7 @@ module UsePackwerk
     desc 'regenerate_rubocop_todo [ packs/my_pack packs/my_other_pack ]', "Regenerate packs/*/#{RuboCop::Packs::PACK_LEVEL_RUBOCOP_TODO_YML} for one or more packs"
     sig { params(pack_names: String).void }
     def regenerate_rubocop_todo(*pack_names)
-      RuboCop::Packs.auto_generate_rubocop_todo(packs: parse_pack_names(pack_names))
+      RuboCop::Packs.regenerate_todo(packs: parse_pack_names(pack_names))
     end
 
     private

--- a/lib/use_packwerk/cli.rb
+++ b/lib/use_packwerk/cli.rb
@@ -98,9 +98,12 @@ module UsePackwerk
 
     private
 
-    sig { params(pack_names: T::Array[String]).returns(T::Array[ParsePackwerk::Package]) }
-    def parse_pack_names(pack_names)
-      pack_names.empty? ? ParsePackwerk.all : pack_names.map { |p| ParsePackwerk.find(p.gsub(%r{/$}, '')) }.compact
+    # This is used by thor to know that these private methods are not intended to be CLI commands
+    no_commands do
+      sig { params(pack_names: T::Array[String]).returns(T::Array[ParsePackwerk::Package]) }
+      def parse_pack_names(pack_names)
+        pack_names.empty? ? ParsePackwerk.all : pack_names.map { |p| ParsePackwerk.find(p.gsub(%r{/$}, '')) }.compact
+      end
     end
   end
 end

--- a/lib/use_packwerk/cli.rb
+++ b/lib/use_packwerk/cli.rb
@@ -87,8 +87,20 @@ module UsePackwerk
     desc 'lint_package_yml_files [ packs/my_pack packs/my_other_pack ]', 'Lint `package.yml` files'
     sig { params(pack_names: String).void }
     def lint_package_yml_files(*pack_names)
-      packages = pack_names.empty? ? ParsePackwerk.all : pack_names.map { |p| ParsePackwerk.find(p.gsub(%r{/$}, '')) }.compact
-      UsePackwerk.lint_package_yml_files!(packages)
+      UsePackwerk.lint_package_yml_files!(parse_pack_names(pack_names))
+    end
+
+    desc 'regenerate_rubocop_todo [ packs/my_pack packs/my_other_pack ]', "Regenerate packs/*/#{RuboCop::Packs::PACK_LEVEL_RUBOCOP_TODO_YML} for one or more packs"
+    sig { params(pack_names: String).void }
+    def regenerate_rubocop_todo(*pack_names)
+      RuboCop::Packs.auto_generate_rubocop_todo(packs: parse_pack_names(pack_names))
+    end
+
+    private
+
+    sig { params(pack_names: T::Array[String]).returns(T::Array[ParsePackwerk::Package]) }
+    def parse_pack_names(pack_names)
+      pack_names.empty? ? ParsePackwerk.all : pack_names.map { |p| ParsePackwerk.find(p.gsub(%r{/$}, '')) }.compact
     end
   end
 end

--- a/lib/use_packwerk/code_ownership_post_processor.rb
+++ b/lib/use_packwerk/code_ownership_post_processor.rb
@@ -40,8 +40,8 @@ module UsePackwerk
       end
     end
 
-    sig { void }
-    def after_move_files!
+    sig { params(file_move_operations: T::Array[Private::FileMoveOperation]).void }
+    def after_move_files!(file_move_operations)
       if @teams.any?
         Logging.section('Code Ownership') do
           Logging.print('This section contains info about the current ownership distribution of the moved files.')

--- a/lib/use_packwerk/code_ownership_post_processor.rb
+++ b/lib/use_packwerk/code_ownership_post_processor.rb
@@ -41,7 +41,7 @@ module UsePackwerk
     end
 
     sig { void }
-    def print_final_message!
+    def after_move_files!
       if @teams.any?
         Logging.section('Code Ownership') do
           Logging.print('This section contains info about the current ownership distribution of the moved files.')

--- a/lib/use_packwerk/per_file_processor_interface.rb
+++ b/lib/use_packwerk/per_file_processor_interface.rb
@@ -10,8 +10,8 @@ module UsePackwerk
     sig { abstract.params(file_move_operation: Private::FileMoveOperation).void }
     def before_move_file!(file_move_operation); end
 
-    sig { void }
-    def after_move_files!
+    sig { params(file_move_operations: T::Array[Private::FileMoveOperation]).void }
+    def after_move_files!(file_move_operations)
       nil
     end
   end

--- a/lib/use_packwerk/per_file_processor_interface.rb
+++ b/lib/use_packwerk/per_file_processor_interface.rb
@@ -11,7 +11,7 @@ module UsePackwerk
     def before_move_file!(file_move_operation); end
 
     sig { void }
-    def print_final_message!
+    def after_move_files!
       nil
     end
   end

--- a/lib/use_packwerk/private.rb
+++ b/lib/use_packwerk/private.rb
@@ -87,6 +87,8 @@ module UsePackwerk
       add_readme_todo(package)
       package_location = package.directory
 
+      file_move_operations = T.let([], T::Array[Private::FileMoveOperation])
+
       if paths_relative_to_root.any?
         Logging.section('File Operations') do
           file_paths = paths_relative_to_root.flat_map do |path|
@@ -130,7 +132,9 @@ module UsePackwerk
         end
       end
 
-      per_file_processors.each(&:after_move_files!)
+      per_file_processors.each do |processor|
+        processor.after_move_files!(file_move_operations)
+      end
     end
 
     sig do
@@ -220,6 +224,8 @@ module UsePackwerk
     end
     def self.make_public!(paths_relative_to_root:, per_file_processors:)
       if paths_relative_to_root.any?
+        file_move_operations = T.let([], T::Array[Private::FileMoveOperation])
+
         Logging.section('File Operations') do
           file_paths = paths_relative_to_root.flat_map do |path|
             origin_pathname = Pathname.new(path).cleanpath
@@ -249,6 +255,10 @@ module UsePackwerk
           file_move_operations.each do |file_move_operation|
             Private.package_filepath(file_move_operation, per_file_processors)
           end
+        end
+
+        per_file_processors.each do |processor|
+          processor.after_move_files!(file_move_operations)
         end
       end
     end

--- a/lib/use_packwerk/private.rb
+++ b/lib/use_packwerk/private.rb
@@ -123,7 +123,7 @@ module UsePackwerk
             )
             [
               file_move_operation,
-              file_move_operation.spec_file_move_operation,
+              file_move_operation.spec_file_move_operation
             ]
           end
           file_move_operations.each do |file_move_operation|

--- a/lib/use_packwerk/private.rb
+++ b/lib/use_packwerk/private.rb
@@ -387,8 +387,8 @@ module UsePackwerk
     sig { void }
     def self.bust_cache!
       UsePackwerk.config.bust_cache!
-      # This comes explicitly after `PackageProtections.config.bust_cache!` because
-      # otherwise `PackageProtections.config` will attempt to reload the client configuratoin.
+      # This comes explicitly after `UsePackwerk.config.bust_cache!` because
+      # otherwise `UsePackwerk.config` will attempt to reload the client configuratoin.
       @loaded_client_configuration = false
     end
 

--- a/lib/use_packwerk/private/interactive_cli/use_cases/regenerate_rubocop_todo.rb
+++ b/lib/use_packwerk/private/interactive_cli/use_cases/regenerate_rubocop_todo.rb
@@ -12,7 +12,7 @@ module UsePackwerk
           sig { override.params(prompt: TTY::Prompt).void }
           def perform!(prompt)
             packs = PackSelector.single_or_all_pack_multi_select(prompt, question_text: "Please select the packs you want to regenerate `#{RuboCop::Packs::PACK_LEVEL_RUBOCOP_TODO_YML}` for")
-            RuboCop::Packs.auto_generate_rubocop_todo(packs: packs)
+            RuboCop::Packs.regenerate_todo(packs: packs)
           end
 
           sig { override.returns(String) }

--- a/lib/use_packwerk/private/packwerk_wrapper/offenses_aggregator_formatter.rb
+++ b/lib/use_packwerk/private/packwerk_wrapper/offenses_aggregator_formatter.rb
@@ -4,7 +4,7 @@ module UsePackwerk
   module Private
     module PackwerkWrapper
       #
-      # This formatter simply collects offenses so we can feed them into PackageProtections
+      # This formatter simply collects offenses so we can feed them into other systems
       #
       class OffensesAggregatorFormatter
         extend T::Sig

--- a/lib/use_packwerk/rubocop_post_processor.rb
+++ b/lib/use_packwerk/rubocop_post_processor.rb
@@ -21,6 +21,7 @@ module UsePackwerk
 
       if file_move_operation.origin_pack.name != ParsePackwerk::ROOT_PACKAGE_NAME && file_move_operation.destination_pack.name != ParsePackwerk::ROOT_PACKAGE_NAME
         origin_rubocop_todo = file_move_operation.origin_pack.directory.join(RuboCop::Packs::PACK_LEVEL_RUBOCOP_TODO_YML)
+        # If there were TODOs for this file in the origin pack's pack-based rubocop, we want to move it to the destination
         if origin_rubocop_todo.exist?
           loaded_origin_rubocop_todo = YAML.load_file(origin_rubocop_todo)
           new_origin_rubocop_todo = loaded_origin_rubocop_todo.dup

--- a/lib/use_packwerk/rubocop_post_processor.rb
+++ b/lib/use_packwerk/rubocop_post_processor.rb
@@ -47,5 +47,21 @@ module UsePackwerk
         end
       end
     end
+
+    sig { params(file_move_operations: T::Array[Private::FileMoveOperation]).void }
+    def after_move_files!(file_move_operations)
+      # There could also be no TODOs for this file, but moving it produced TODOs. This could happen if:
+      # 1) The origin pack did not enforce a rubocop, such as typed public APIs
+      # 2) The file satisfied the cop in the origin pack, such as the Packs/RootNamespaceIsPackName, but the desired
+      # namespace changed once the file was moved to a different pack.
+      files = []
+      file_move_operations.each do |file_move_operation|
+        if file_move_operation.destination_pathname.exist?
+          files << file_move_operation.destination_pathname.to_s
+        end
+      end
+
+      RuboCop::Packs.regenerate_todo(files: files)
+    end
   end
 end

--- a/lib/use_packwerk/user_event_logger.rb
+++ b/lib/use_packwerk/user_event_logger.rb
@@ -23,11 +23,9 @@ module UsePackwerk
 
         2) Run `bin/packwerk update-deprecations` to update the violations. Make sure to run `spring stop` if you've added new load paths (new top-level directories) in your pack.
 
-        3) Update TODO lists for rubocop implemented protections. See #{documentation_link} for more info
+        3) Expose public API in #{pack_name}/app/public. Try `bin/packs make_public #{pack_name}/path/to/file.rb`
 
-        4) Expose public API in #{pack_name}/app/public. Try `bin/packs make_public #{pack_name}/path/to/file.rb`
-
-        5) Update your readme at #{pack_name}/README.md
+        4) Update your readme at #{pack_name}/README.md
       MSG
     end
 
@@ -45,13 +43,11 @@ module UsePackwerk
 
         1) Run `bin/packwerk update-deprecations` to update the violations. Make sure to run `spring stop` if you've added new load paths (new top-level directories) in your pack.
 
-        2) Update TODO lists for rubocop implemented protections. See #{documentation_link} for more info
+        2) Touch base with each team who owns files involved in this move
 
-        3) Touch base with each team who owns files involved in this move
+        3) Expose public API in #{pack_name}/app/public. Try `bin/packs make_public #{pack_name}/path/to/file.rb`
 
-        4) Expose public API in #{pack_name}/app/public. Try `bin/packs make_public #{pack_name}/path/to/file.rb`
-
-        5) Update your readme at #{pack_name}/README.md
+        4) Update your readme at #{pack_name}/README.md
       MSG
     end
 
@@ -69,11 +65,9 @@ module UsePackwerk
 
         1) Run `bin/packwerk update-deprecations` to update the violations. Make sure to run `spring stop` if you've added new load paths (new top-level directories) in your pack.
 
-        2) Update TODO lists for rubocop implemented protections. See #{documentation_link} for more info
+        2) Work to migrate clients of private API to your new public API
 
-        3) Work to migrate clients of private API to your new public API
-
-        4) Update your README at packs/your_package_name/README.md
+        3) Update your README at packs/your_package_name/README.md
       MSG
     end
 

--- a/sorbet/rbi/gems/rubocop-packs@0.0.27.rbi
+++ b/sorbet/rbi/gems/rubocop-packs@0.0.27.rbi
@@ -145,9 +145,6 @@ RuboCop::NodePattern = RuboCop::AST::NodePattern
 
 module RuboCop::Packs
   class << self
-    sig { params(packs: T::Array[::ParsePackwerk::Package]).void }
-    def auto_generate_rubocop_todo(packs:); end
-
     sig { void }
     def bust_cache!; end
 
@@ -163,6 +160,9 @@ module RuboCop::Packs
     sig { params(root_pathname: ::String).returns(::String) }
     def pack_based_rubocop_config(root_pathname: T.unsafe(nil)); end
 
+    sig { params(packs: T::Array[::ParsePackwerk::Package], files: T::Array[::String]).void }
+    def regenerate_todo(packs: T.unsafe(nil), files: T.unsafe(nil)); end
+
     sig { params(packs: T::Array[::ParsePackwerk::Package]).void }
     def set_default_rubocop_yml(packs:); end
 
@@ -173,7 +173,6 @@ end
 
 RuboCop::Packs::CONFIG = T.let(T.unsafe(nil), Hash)
 RuboCop::Packs::CONFIG_DEFAULT = T.let(T.unsafe(nil), Pathname)
-class RuboCop::Packs::Error < ::StandardError; end
 
 module RuboCop::Packs::Inject
   class << self
@@ -194,8 +193,19 @@ module RuboCop::Packs::Private
     sig { params(rule: ::String).returns(T::Set[::String]) }
     def exclude_for_rule(rule); end
 
+    sig { params(args: T.untyped).void }
+    def execute_rubocop(args); end
+
     sig { void }
     def load_client_configuration; end
+
+    sig do
+      params(
+        paths: T::Array[::String],
+        cop_names: T::Array[::String]
+      ).returns(T::Array[::RuboCop::Packs::Private::Offense])
+    end
+    def offenses_for(paths:, cop_names:); end
 
     sig { returns(T::Array[T::Hash[T.untyped, T.untyped]]) }
     def rubocop_todo_ymls; end
@@ -232,6 +242,18 @@ class RuboCop::Packs::Private::Configuration
   def required_pack_level_cops; end
 
   def required_pack_level_cops=(_arg0); end
+end
+
+class RuboCop::Packs::Private::Offense < ::T::Struct
+  const :cop_name, ::String
+  const :filepath, ::String
+
+  sig { returns(::ParsePackwerk::Package) }
+  def pack; end
+
+  class << self
+    def inherited(s); end
+  end
 end
 
 module RuboCop::PackwerkLite; end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,8 +46,6 @@ sig do
     dependencies: T::Array[String],
     enforce_dependencies: T::Boolean,
     enforce_privacy: T::Boolean,
-    protections: T.untyped,
-    global_namespaces: T::Array[String],
     visible_to: T::Array[String],
     metadata: T.untyped,
     owner: T.nilable(String)
@@ -58,21 +56,10 @@ def write_package_yml(
   dependencies: [],
   enforce_dependencies: true,
   enforce_privacy: true,
-  protections: {},
-  global_namespaces: [],
   visible_to: [],
   metadata: {},
   owner: nil
 )
-  defaults = {
-    'prevent_this_package_from_violating_its_stated_dependencies' => 'fail_on_new',
-    'prevent_other_packages_from_using_this_packages_internals' => 'fail_on_new',
-    'prevent_this_package_from_exposing_an_untyped_api' => 'fail_on_new',
-    'prevent_this_package_from_creating_other_namespaces' => 'fail_on_new'
-  }
-  protections_with_defaults = defaults.merge(protections)
-  metadata.merge!({ 'protections' => protections_with_defaults })
-
   if owner
     metadata.merge!({ 'owner' => owner })
   end

--- a/spec/use_packwerk_spec.rb
+++ b/spec/use_packwerk_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe UsePackwerk do
     CodeTeams.bust_caches!
     # Always add the root package for every spec
     write_package_yml('.')
+    allow(RuboCop::Packs).to receive(:regenerate_todo)
   end
 
   describe '.create_pack!' do

--- a/spec/use_packwerk_spec.rb
+++ b/spec/use_packwerk_spec.rb
@@ -598,6 +598,19 @@ RSpec.describe UsePackwerk do
                                                  })
           end
         end
+
+        it 'runs rubocop on the changed files' do
+          UsePackwerk.create_pack!(pack_name: 'packs/fruits/apples')
+          ParsePackwerk.bust_cache!
+          write_file('packs/fruits/apples/app/services/apple.rb')
+
+          expect(RuboCop::Packs).to receive(:regenerate_todo).with(files: ['packs/fruits/apples/app/public/apple.rb'])
+
+          UsePackwerk.make_public!(
+            paths_relative_to_root: ['packs/fruits/apples/app/services/apple.rb'],
+            per_file_processors: [UsePackwerk::RubocopPostProcessor.new]
+          )
+        end
       end
 
       describe 'CodeOwnershipPostProcessor' do

--- a/spec/use_packwerk_spec.rb
+++ b/spec/use_packwerk_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe UsePackwerk do
     # Always add the root package for every spec
     write_package_yml('.')
     allow(RuboCop::Packs).to receive(:regenerate_todo)
+    allow(UsePackwerk::Logging).to receive(:out)
+    allow(UsePackwerk::Logging).to receive(:print)
   end
 
   describe '.create_pack!' do
@@ -1211,6 +1213,11 @@ RSpec.describe UsePackwerk do
         logged_output += "\n"
       end
 
+      expect(UsePackwerk::Logging).to receive(:print).at_least(:once) do |string|
+        logged_output += ColorizedString.new(string).uncolorize
+        logged_output += "\n"
+      end
+
       write_package_yml('packs/fruits')
       write_package_yml('packs/apples')
       write_file('packs/apples/app/services/apples/foo.rb')
@@ -1553,7 +1560,6 @@ RSpec.describe UsePackwerk do
           end
 
           list_top_privacy_violations
-          puts logged_output
 
           expected_logged_output = <<~OUTPUT
             Total Count: 4
@@ -1578,7 +1584,6 @@ RSpec.describe UsePackwerk do
           end
 
           list_top_privacy_violations
-          puts logged_output
 
           expected_logged_output = <<~OUTPUT
             Total Count: 3
@@ -1603,7 +1608,6 @@ RSpec.describe UsePackwerk do
           end
 
           list_top_privacy_violations
-          puts logged_output
 
           expected_logged_output = <<~OUTPUT
             Total Count: 4
@@ -1634,7 +1638,6 @@ RSpec.describe UsePackwerk do
             end
 
             list_top_privacy_violations
-            puts logged_output
 
             expected_logged_output = <<~OUTPUT
               Total Count: 4
@@ -1663,7 +1666,6 @@ RSpec.describe UsePackwerk do
           end
 
           list_top_privacy_violations
-          puts logged_output
 
           expected_logged_output = <<~OUTPUT
             Total Count: 3
@@ -1689,8 +1691,6 @@ RSpec.describe UsePackwerk do
             pack_name: nil,
             limit: limit
           )
-
-          puts logged_output
 
           expected_logged_output = <<~OUTPUT
             Total Count: 11
@@ -1743,7 +1743,6 @@ RSpec.describe UsePackwerk do
           end
 
           list_top_dependency_violations
-          puts logged_output
 
           expected_logged_output = <<~OUTPUT
             Total Count: 4
@@ -1768,7 +1767,6 @@ RSpec.describe UsePackwerk do
           end
 
           list_top_dependency_violations
-          puts logged_output
 
           expected_logged_output = <<~OUTPUT
             Total Count: 4
@@ -1796,7 +1794,6 @@ RSpec.describe UsePackwerk do
           end
 
           list_top_dependency_violations
-          puts logged_output
 
           expected_logged_output = <<~OUTPUT
             Total Count: 4
@@ -1827,7 +1824,6 @@ RSpec.describe UsePackwerk do
             end
 
             list_top_dependency_violations
-            puts logged_output
 
             expected_logged_output = <<~OUTPUT
               Total Count: 4
@@ -1856,7 +1852,6 @@ RSpec.describe UsePackwerk do
           end
 
           list_top_dependency_violations
-          puts logged_output
 
           expected_logged_output = <<~OUTPUT
             Total Count: 4
@@ -1885,8 +1880,6 @@ RSpec.describe UsePackwerk do
             pack_name: nil,
             limit: limit
           )
-
-          puts logged_output
 
           expected_logged_output = <<~OUTPUT
             Total Count: 12

--- a/use_packwerk.gemspec
+++ b/use_packwerk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'use_packwerk'
-  spec.version       = '0.67.0'
+  spec.version       = '0.68.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 


### PR DESCRIPTION
Best viewed commit by commit

# Commits
- Add bin/packs regenerate_rubocop_todo
- Reorganize how spec file move operations are constructed so we can pass in file move operations to per file processor after move files
- use updated RP API
- remove mentions of PP and other outdated APIs
- update API to after_move_files to take in file operations
- run rubocop regenerate_todo after moving files
- Tell thor private methods should not be commands
- bump rubocop-packs
- rubocop
- Add allow so we do not attempt to execute rubocop during specs
- Clean up test output
- bump version