### PR TITLE
Alphabetize the Team list for easier selection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    use_packwerk (0.69.0)
+    use_packwerk (0.70.0)
       code_ownership
       colorize
       packwerk (>= 2.2.1)
@@ -124,7 +124,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.21.0)
       parser (>= 3.1.1.0)
-    rubocop-packs (0.0.27)
+    rubocop-packs (0.0.29)
       activesupport
       parse_packwerk
       rubocop

--- a/lib/use_packwerk/private/interactive_cli/team_selector.rb
+++ b/lib/use_packwerk/private/interactive_cli/team_selector.rb
@@ -8,7 +8,7 @@ module UsePackwerk
 
         sig { params(prompt: TTY::Prompt, question_text: String).returns(CodeTeams::Team) }
         def self.single_select(prompt, question_text: 'Please select a team owner')
-          teams = CodeTeams.all.to_h { |t| [t.name, t] }
+          teams = CodeTeams.all.sort_by(&:name).to_h { |t| [t.name, t] }
           prompt.select(
             question_text,
             teams,

--- a/spec/use_packwerk/private/interactive_cli_spec.rb
+++ b/spec/use_packwerk/private/interactive_cli_spec.rb
@@ -9,12 +9,29 @@ module UsePackwerk
       Private::InteractiveCli.start!(prompt: prompt)
     end
 
+    before { CodeTeams.bust_caches! }
+
     it 'allows creating a new pack interactively' do
       write_file('config/teams/artists.yml', 'name: Artists')
       expect(UsePackwerk).to receive(:create_pack!).with(pack_name: 'packs/my_new_pack', team: CodeTeams.find('Artists'))
       prompt.input << "Create\r"
       prompt.input << "my_new_pack\r"
       prompt.input << "Artists\r"
+      prompt.input.rewind
+      subject
+    end
+
+    it 'shows teams listed alphabetically and you can pick one with arrow keys' do
+      write_file('config/teams/zebras.yml', 'name: Zebras')
+      write_file('config/teams/artists.yml', 'name: Artists')
+      write_file('config/teams/bbs.yml', 'name: BBs')
+
+      expect(UsePackwerk).to receive(:create_pack!).with(pack_name: 'packs/my_new_pack', team: CodeTeams.find('Zebras'))
+      prompt.input << "Create\r"
+      prompt.input << "my_new_pack\r"
+      prompt.input << "\e[B" # down arrow
+      prompt.input << "\e[B" # down arrow
+      prompt.input << "\r"
       prompt.input.rewind
       subject
     end

--- a/use_packwerk.gemspec
+++ b/use_packwerk.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'use_packwerk'
-  spec.version       = '0.69.0'
+  spec.version       = '0.70.0'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
 


### PR DESCRIPTION
Problem
-------

If I run `bin/packs` and create a new pack, when I get to the team list it's in what looks like a random order.

```bash
❯ bin/packs
Hello! What would you like to do? Create a new pack
What should the name of your pack be? packs/whatever
Please select a team owner (Press ↑/↓/←/→ arrow to move, Enter to select and letters to filter)
‣ Team 5
  Apples Team
  Search
  Other Team
```

We do have autocomplete with typing but you can also scroll through by arrow keys. If you use the latter method, it might be nice to have these in order.

Solution
--------

Sort the list of teams by name before sending to the prompt.

```bash
❯ bin/packs
Hello! What would you like to do? Create a new pack
What should the name of your pack be? packs/whatever
Please select a team owner (Press ↑/↓/←/→ arrow to move, Enter to select and letters to filter)
‣ Apples Team
  Other Team
  Search
  Team 5
```